### PR TITLE
metrics: Bind command method to its ES6 class instance.

### DIFF
--- a/src/decorator/metrics.js
+++ b/src/decorator/metrics.js
@@ -50,12 +50,18 @@ const wrapCommandMethod = function(data, oldMethod) {
 
 const wrapCommand = function(gen, data) {
     const name = gen.command.constructor.name;
-    
+
     data[name] = data[name] || emptyOutput();
     ++data[name].generated;
 
-    gen.command.check = wrapSyncCommandMethod(data[name].check, gen.command.check);
-    gen.command.run = wrapCommandMethod(data[name].run, gen.command.run);
+    gen.command.check = wrapSyncCommandMethod(
+        data[name].check,
+        gen.command.check.bind(gen.command)
+    );
+    gen.command.run = wrapCommandMethod(
+        data[name].run,
+        gen.command.run.bind(gen.command)
+    );
 
     const oldShrink = gen.shrink;
     gen.shrink = () => {


### PR DESCRIPTION
If I define a Command in ES6 class syntax, the check and run methods do not have access to the instance with `this`.